### PR TITLE
temporary solution to support multi-user usecase in MCP servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aci-mcp"
-version = "1.0.0b3"
+version = "1.0.0b4"
 description = "ACI MCP server, built on top of ACI.dev by Aipolabs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aci_mcp/unified_server.py
+++ b/src/aci_mcp/unified_server.py
@@ -73,11 +73,23 @@ async def handle_call_tool(
         arguments["limit"] = 15
         arguments["offset"] = 0
 
+    # TODO: temporary solution to support multi-user usecases due to the limitation of MCP protocol.
+    # What happens here is that we allow user (MCP clients) to pass in the 
+    # "aci_override_linked_account_owner_id" parameter for the ACI_EXECUTE_FUNCTION tool call 
+    # (apart from the "function_name" and "function_arguments" parameters), to override the 
+    # default value of the "linked_account_owner_id".
+    # The --linked-account-owner-id flag that we use to start the MCP server will be used as the 
+    # default value of the "linked_account_owner_id".
+    linked_account_owner_id = LINKED_ACCOUNT_OWNER_ID
+    if name == aci_execute_function["name"] and "aci_override_linked_account_owner_id" in arguments:
+        linked_account_owner_id = str(arguments["aci_override_linked_account_owner_id"])
+        del arguments["aci_override_linked_account_owner_id"]
+
     try:
         result = aci.handle_function_call(
             name,
             arguments,
-            linked_account_owner_id=LINKED_ACCOUNT_OWNER_ID,
+            linked_account_owner_id=linked_account_owner_id,
             allowed_apps_only=ALLOWED_APPS_ONLY,
             format=FunctionDefinitionFormat.ANTHROPIC,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "aci-mcp"
-version = "1.0.0b3"
+version = "1.0.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "aci-sdk" },


### PR DESCRIPTION
Temporary solution to allow linked_account_owner_id override to support multi-user usecase.
The choice of using aci_override_linked_account_owner_id instead of using below dict style parameter is to lower the chance of parameter name clashing.  (i.e, it's less likely that a tool argument's name is `aci_override_xxx` compared to just `aci_override` )
`{
    "aci_override": {
        "linked_account_owner_id": "xxx"
    }
 }
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for overriding the linked account owner ID on a per-call basis in multi-user scenarios.

- **Chores**
  - Updated project version to 1.0.0b4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->