### PR TITLE
fix: by default only use allowed apps

### DIFF
--- a/src/aci_mcp/__init__.py
+++ b/src/aci_mcp/__init__.py
@@ -1,6 +1,9 @@
-import click
 import os
+
+import click
+
 from .common import validators
+
 
 @click.group()
 def main():
@@ -19,7 +22,8 @@ def main():
     "--linked-account-owner-id",
     required=True,
     type=str,
-    help="the owner id of the linked accounts to use for the tool calls. You'll need to create the linked accounts on platform.aci.dev",
+    help="the owner id of the linked accounts to use for the tool calls. "
+    "You'll need to create the linked accounts on platform.aci.dev",
 )
 @click.option(
     "--transport",
@@ -42,16 +46,18 @@ def start_apps_server(apps: str, linked_account_owner_id: str, transport: str, p
 
 @main.command(name="unified-server")
 @click.option(
-    "--allow-all-apps",
+    "--search-all-apps",
     is_flag=True,
     default=False,
-    help="Allow the search function to discover all apps, not just the allowed apps that are accessible to this agent (identified by ACI_API_KEY)",
+    help="Allow the search function to discover all apps, not just the allowed apps "
+    "that are accessible to this agent (identified by ACI_API_KEY)",
 )
 @click.option(
     "--linked-account-owner-id",
     required=True,
     type=str,
-    help="the owner id of the linked account to use for the tool calls",
+    help="the owner id of the linked account to use for the tool calls. "
+    "You'll need to create the linked account on platform.aci.dev",
 )
 @click.option(
     "--transport",
@@ -61,11 +67,16 @@ def start_apps_server(apps: str, linked_account_owner_id: str, transport: str, p
 )
 @click.option("--port", default=8000, help="Port to listen on for SSE")
 def start_unified_server(
-    allow_all_apps: bool, linked_account_owner_id: str, transport: str, port: int
+    search_all_apps: bool, linked_account_owner_id: str, transport: str, port: int
 ) -> None:
     """Start the unified MCP server with unlimited tool access."""
     from .unified_server import start
 
     validators.validate_api_key(os.getenv("ACI_API_KEY"))
 
-    return start(allowed_apps_only=not allow_all_apps, linked_account_owner_id=linked_account_owner_id, transport=transport, port=port)
+    return start(
+        allowed_apps_only=not search_all_apps,
+        linked_account_owner_id=linked_account_owner_id,
+        transport=transport,
+        port=port,
+    )

--- a/src/aci_mcp/__init__.py
+++ b/src/aci_mcp/__init__.py
@@ -42,10 +42,10 @@ def start_apps_server(apps: str, linked_account_owner_id: str, transport: str, p
 
 @main.command(name="unified-server")
 @click.option(
-    "--allowed-apps-only",
+    "--allow-all-apps",
     is_flag=True,
     default=False,
-    help="Limit the functions (tools) search to only the allowed apps that are accessible to this agent. (identified by ACI_API_KEY)",
+    help="Allow the search function to discover all apps, not just the allowed apps that are accessible to this agent (identified by ACI_API_KEY)",
 )
 @click.option(
     "--linked-account-owner-id",
@@ -61,11 +61,11 @@ def start_apps_server(apps: str, linked_account_owner_id: str, transport: str, p
 )
 @click.option("--port", default=8000, help="Port to listen on for SSE")
 def start_unified_server(
-    allowed_apps_only: bool, linked_account_owner_id: str, transport: str, port: int
+    allow_all_apps: bool, linked_account_owner_id: str, transport: str, port: int
 ) -> None:
     """Start the unified MCP server with unlimited tool access."""
     from .unified_server import start
 
     validators.validate_api_key(os.getenv("ACI_API_KEY"))
 
-    return start(allowed_apps_only, linked_account_owner_id, transport, port)
+    return start(allowed_apps_only=not allow_all_apps, linked_account_owner_id=linked_account_owner_id, transport=transport, port=port)

--- a/src/aci_mcp/common/validators.py
+++ b/src/aci_mcp/common/validators.py
@@ -9,7 +9,7 @@ def validate_apps_configured(apps: list[str]) -> None:
 # TODO:
 def validate_linked_accounts_exist(apps: list[str], linked_account_owner_id: str) -> None:
     """
-    Validate that the linked accounts (identified by the linked_account_owner_id + app name) 
+    Validate that the linked accounts (identified by the linked_account_owner_id + app name)
     exist on platform.aci.dev.
     """
     pass

--- a/src/aci_mcp/unified_server.py
+++ b/src/aci_mcp/unified_server.py
@@ -28,6 +28,7 @@ aci_execute_function = ACIExecuteFunction.to_json_schema(FunctionDefinitionForma
 aci_search_functions["input_schema"]["properties"].pop("limit", None)
 aci_search_functions["input_schema"]["properties"].pop("offset", None)
 
+
 def _set_up(allowed_apps_only: bool, linked_account_owner_id: str):
     """
     Set up global variables
@@ -67,18 +68,18 @@ async def handle_call_tool(
     if not arguments:
         arguments = {}
 
-    # TODO: if it's ACI_SEARCH_FUNCTIONS, populate default values for limit and offset because we 
+    # TODO: if it's ACI_SEARCH_FUNCTIONS, populate default values for limit and offset because we
     # removed them from the input schema at the top of this file.
     if name == aci_search_functions["name"]:
         arguments["limit"] = 15
         arguments["offset"] = 0
 
     # TODO: temporary solution to support multi-user usecases due to the limitation of MCP protocol.
-    # What happens here is that we allow user (MCP clients) to pass in the 
-    # "aci_override_linked_account_owner_id" parameter for the ACI_EXECUTE_FUNCTION tool call 
-    # (apart from the "function_name" and "function_arguments" parameters), to override the 
+    # What happens here is that we allow user (MCP clients) to pass in the
+    # "aci_override_linked_account_owner_id" parameter for the ACI_EXECUTE_FUNCTION tool call
+    # (apart from the "function_name" and "function_arguments" parameters), to override the
     # default value of the "linked_account_owner_id".
-    # The --linked-account-owner-id flag that we use to start the MCP server will be used as the 
+    # The --linked-account-owner-id flag that we use to start the MCP server will be used as the
     # default value of the "linked_account_owner_id".
     linked_account_owner_id = LINKED_ACCOUNT_OWNER_ID
     if name == aci_execute_function["name"] and "aci_override_linked_account_owner_id" in arguments:


### PR DESCRIPTION

Changed the `--allowed-apps-only` flag to `--search-all-apps` and reverted the logic so that the default is only use allowed apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated command-line option to allow discovery of all apps with a clearer flag name.
- **Documentation**
	- Improved help text for the command-line option to clarify its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->