### PR TITLE
Fix ACI_SERVER_URL default value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aci-mcp"
-version = "1.0.0b12"
+version = "1.0.0b13"
 description = "ACI MCP server, built on top of ACI.dev by Aipolabs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aci_mcp/unified_server.py
+++ b/src/aci_mcp/unified_server.py
@@ -24,7 +24,7 @@ if not ACI_API_KEY:
         "ACI_API_KEY environment variable is not set. Please set it to your ACI API key."
     )
 
-ACI_SERVER_URL = os.getenv("ACI_SERVER_URL", "https://api.aci.dev")
+ACI_SERVER_URL = os.getenv("ACI_SERVER_URL", "https://api.aci.dev/v1")
 
 ALLOWED_APPS_ONLY = False
 LINKED_ACCOUNT_OWNER_ID = ""


### PR DESCRIPTION
The URL has to include `/v1`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the default ACI_SERVER_URL to include the /v1 path, ensuring correct API endpoint usage.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version number to 1.0.0b13.

* **Bug Fixes**
  * Changed the default API server URL to include the `/v1` version path for improved endpoint compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->